### PR TITLE
Handle case where function caller is null

### DIFF
--- a/stack-generator.js
+++ b/stack-generator.js
@@ -22,6 +22,9 @@
 
             var curr = arguments.callee;
             while (curr && stack.length < maxStackSize) {
+                if (!curr['arguments']) {
+                  break;
+                }
                 // Allow V8 optimizations
                 var args = new Array(curr['arguments'].length);
                 for (var i = 0; i < args.length; ++i) {


### PR DESCRIPTION
I ran into an issue where `arguments.callee` (`curr`) is defined, but `arguments.callee.arguments` (`curr['arguments']`) is `null` on the following line: 
https://github.com/stacktracejs/stack-generator/blob/258596727d6132a6ca95616719a99a2b6ca01c8f/stack-generator.js#L26

This is a very specific issue that only affects certain browsers (notably my automated tests in IE10 failed for this reason) when a script is added to the page when trying to traverse the callee/caller chain to the top level.

Placing the two files from [this gist](https://gist.github.com/bengourley/c84451d3413fc51aa21b4176e0618160) yields the following error in IE10:

![image](https://user-images.githubusercontent.com/609579/31506067-4ff02656-af6e-11e7-86fe-e23695546348.png)

Since this is quite specific, I couldn't figure out the best way to add something to the automated test suite in this repo without adding a bunch of complexity.

Let me know if tests are needed and how to proceed if so!
