### PR TITLE
Fix travis.yml (trusty > xenial)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,11 @@ addons:
     - google-chrome
     packages:
     - google-chrome-stable
+services:
+  - xvfb
 before_install:
 - export CHROME_BIN=chromium-browser
 - export DISPLAY=:99.0
-- sh -e /etc/init.d/xvfb start
 before_script:
 - npm install
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 sudo: required
-dist: trusty
+dist: xenial
 node_js:
  - 8
 addons:


### PR DESCRIPTION
Builds otherwise fail without this.

Ref: <https://travis-ci.community/t/travis-is-downloading-older-chrome-versions-in-place-of-chrome-stable/5040/4>